### PR TITLE
fix: install Playwright system dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
           cd e2e
           npm ci
           npx playwright install chromium
+          sudo npx playwright install-deps
 
       - name: Run browser tests
         run: |


### PR DESCRIPTION
## Summary
- Add `sudo npx playwright install-deps` to CI workflow to resolve browser test failures
- Fixes missing system libraries required by Playwright in GitHub Actions runner

## Test plan
- [x] Verify CI workflow change is syntactically correct
- [ ] Confirm browser tests pass in GitHub Actions after merge