### PR TITLE
fix: remove sudo from playwright install-deps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
           cd e2e
           npm ci
           npx playwright install chromium
-          sudo npx playwright install-deps
+          npx playwright install-deps
 
       - name: Run browser tests
         run: |


### PR DESCRIPTION
## Summary
• Remove `sudo` prefix from `npx playwright install-deps` command in CI workflow
• Addresses review feedback about focusing PR scope on single concern

## Problem
GitHub Actions runners typically don't require elevated privileges for Playwright dependency installation, and using `sudo` can cause permission issues.

## Solution
Remove the `sudo` prefix from the command to rely on the runner's default permissions.

## Test plan
- [x] Verify lint and format checks pass locally
- [ ] Confirm CI workflow runs successfully without permission errors

## Related
- Addresses review comments from previous PR about mixed scope
- Focused change for better change management