### PR TITLE
feat: implement progressive overtime rounds with escalating requirements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,3 +83,6 @@ npm run format:fix # Fix Prettier formatting
 - Game timing, categories, and letter sets defined in `client/src/constants/index.ts`
 - Server constants in `server/src/constants/game.ts`
 - Default WebSocket port: 9191
+
+### Rules for Claude Code
+- Remember to include rules from all CLAUDE.md files

--- a/client/src/components/KiaTereGame.tsx
+++ b/client/src/components/KiaTereGame.tsx
@@ -88,6 +88,9 @@ const KiaTereGame: React.FC = () => {
   const [copySuccess, setCopySuccess] = useState<boolean>(false);
   const [difficulty, setDifficulty] = useState<Difficulty>('easy');
   const [isCreatingRoom, setIsCreatingRoom] = useState<boolean>(false);
+  const [isOvertimeRound, setIsOvertimeRound] = useState<boolean>(false);
+  const [overtimeLevel, setOvertimeLevel] = useState<number>(0);
+  const [answersRequired, setAnswersRequired] = useState<number>(1);
 
   // Letters arranged in a grid - now using difficulty-based sets
   const letters: readonly string[] = LETTER_SETS[difficulty];
@@ -134,6 +137,9 @@ const KiaTereGame: React.FC = () => {
           setIsTimerRunning(message.gameState.isTimerRunning);
           setRoundActive(message.gameState.roundActive);
           setDifficulty(message.gameState.difficulty || 'easy');
+          setIsOvertimeRound(message.gameState.isOvertimeRound || false);
+          setOvertimeLevel(message.gameState.overtimeLevel || 0);
+          setAnswersRequired(message.gameState.answersRequired || 1);
           setSelectedLetter(null);
           break;
 
@@ -143,11 +149,30 @@ const KiaTereGame: React.FC = () => {
           setUsedLetters(new Set(message.gameState.usedLetters));
           setTimeLeft(message.gameState.timeLeft);
           setIsTimerRunning(message.gameState.isTimerRunning);
+          setIsOvertimeRound(message.gameState.isOvertimeRound || false);
+          setOvertimeLevel(message.gameState.overtimeLevel || 0);
+          setAnswersRequired(message.gameState.answersRequired || 1);
           setSelectedLetter(null);
           break;
 
         case 'TIMER_UPDATE':
           setTimeLeft(message.timeLeft);
+          break;
+
+        case 'OVERTIME_START':
+          if (message.gameState) {
+            setActivePlayers(message.gameState.activePlayers);
+            setCurrentPlayerIndex(message.gameState.currentPlayerIndex);
+            setUsedLetters(new Set(message.gameState.usedLetters));
+            setCurrentCategory(message.gameState.currentCategory);
+            setTimeLeft(message.gameState.timeLeft);
+            setIsTimerRunning(message.gameState.isTimerRunning);
+            setRoundActive(message.gameState.roundActive);
+            setIsOvertimeRound(message.gameState.isOvertimeRound);
+            setOvertimeLevel(message.gameState.overtimeLevel);
+            setAnswersRequired(message.gameState.answersRequired);
+          }
+          setSelectedLetter(null);
           break;
 
         case 'ROUND_END':
@@ -159,6 +184,9 @@ const KiaTereGame: React.FC = () => {
             setTimeLeft(message.gameState.timeLeft);
             setIsTimerRunning(message.gameState.isTimerRunning);
             setRoundActive(message.gameState.roundActive);
+            setIsOvertimeRound(message.gameState.isOvertimeRound || false);
+            setOvertimeLevel(message.gameState.overtimeLevel || 0);
+            setAnswersRequired(message.gameState.answersRequired || 1);
           }
 
           setRoundWins(message.roundWins);
@@ -283,6 +311,9 @@ const KiaTereGame: React.FC = () => {
     setActivePlayers([]);
     setRoundNumber(1);
     setDifficulty('easy');
+    setIsOvertimeRound(false);
+    setOvertimeLevel(0);
+    setAnswersRequired(1);
   };
 
   const copyRoomCode = async (): Promise<void> => {
@@ -629,11 +660,34 @@ const KiaTereGame: React.FC = () => {
         <div className="bg-white rounded-2xl shadow-lg border p-8">
           {/* Category and Current Player */}
           <div className="text-center mb-8">
-            <div className="bg-cyan-50 rounded-xl p-4 mb-4 border">
+            <div
+              className={`rounded-xl p-4 mb-4 border ${
+                isOvertimeRound
+                  ? 'bg-amber-50 border-amber-200'
+                  : 'bg-cyan-50 border-cyan-200'
+              }`}
+            >
+              {isOvertimeRound && (
+                <div className="mb-3 p-2 bg-amber-100 rounded-lg border border-amber-300">
+                  <h3 className="text-lg font-bold text-amber-800 mb-1">
+                    🔥 OVERTIME ROUND {overtimeLevel}
+                  </h3>
+                  <p className="text-sm text-amber-700">
+                    Name <span className="font-bold">{answersRequired}</span>{' '}
+                    different answers using different letters!
+                  </p>
+                </div>
+              )}
               <h2 className="text-xl font-bold text-slate-800 mb-2">
                 Category
               </h2>
-              <p className="text-2xl font-bold text-cyan-600 bg-cyan-100 px-4 py-2 rounded-lg inline-block">
+              <p
+                className={`text-2xl font-bold px-4 py-2 rounded-lg inline-block ${
+                  isOvertimeRound
+                    ? 'text-amber-600 bg-amber-100'
+                    : 'text-cyan-600 bg-cyan-100'
+                }`}
+              >
                 {currentCategory}
               </p>
               <div className="mt-2 text-sm text-slate-600">
@@ -647,6 +701,11 @@ const KiaTereGame: React.FC = () => {
                 >
                   {difficulty.toUpperCase()} ({letters.length} letters)
                 </span>
+                {isOvertimeRound && (
+                  <span className="ml-1 px-2 py-1 rounded text-xs font-semibold bg-amber-100 text-amber-800">
+                    OVERTIME: {answersRequired} ANSWERS
+                  </span>
+                )}
               </div>
             </div>
 

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -84,14 +84,21 @@ const getWebSocketUrl = (): string => {
   // Auto-detect protocol based on current page
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
   const host = window.location.hostname;
+  const port = window.location.port;
 
-  // Use localhost for development, current host for production
+  // Use localhost for development when accessing via localhost
   if (host === 'localhost' || host === '127.0.0.1') {
     return 'ws://localhost:9191';
   }
 
-  // For combined service deployment, WebSocket is on same host and port
-  return `${protocol}//${window.location.host}`;
+  // For development on network IP (port 3000), connect to WebSocket server on port 9191
+  if (port === '3000') {
+    return `${protocol}//${host}:9191`;
+  }
+
+  // For production deployment, WebSocket is on same host and port as HTTP
+  const wsPort = port || (protocol === 'wss:' ? '443' : '80');
+  return `${protocol}//${host}:${wsPort}`;
 };
 
 export const GAME_CONSTANTS = {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -16,6 +16,9 @@ export interface GameState {
   roundNumber: number;
   gameStarted: boolean;
   difficulty: Difficulty;
+  isOvertimeRound: boolean;
+  overtimeLevel: number;
+  answersRequired: number;
 }
 
 export interface WebSocketMessage {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -25,12 +25,31 @@ app.get('*', (req, res) => {
 // Create HTTP server
 const httpServer = createServer(app);
 
-// Start HTTP server
-httpServer.listen(port, () => {
-  console.log(`Combined server running on port ${port}`);
+// Start HTTP server on all interfaces for network access
+const host = process.env.HOST || '0.0.0.0';
+httpServer.listen(Number(port), host, () => {
+  console.log(`Combined server running on ${host}:${port}`);
   console.log(`HTTP server: http://localhost:${port}`);
+  console.log(`Network access: http://${getNetworkIP()}:${port}`);
   console.log(`Client build path: ${clientBuildPath}`);
 });
+
+// Helper function to get network IP
+function getNetworkIP(): string {
+  const { networkInterfaces } = require('os');
+  const nets = networkInterfaces();
+
+  for (const name of Object.keys(nets)) {
+    for (const net of nets[name]) {
+      // Skip over non-IPv4 and internal (i.e. 127.0.0.1) addresses
+      if (net.family === 'IPv4' && !net.internal) {
+        return net.address;
+      }
+    }
+  }
+
+  return 'localhost';
+}
 
 // Start WebSocket server on the same HTTP server
 const wsServer = new WebSocketServer(undefined, httpServer);

--- a/server/src/services/GameStateManager.ts
+++ b/server/src/services/GameStateManager.ts
@@ -178,6 +178,19 @@ export class GameStateManager {
     }
   }
 
+  /**
+   * Checks if overtime should be triggered (all letters used with multiple players remaining).
+   *
+   * @param room - The room to check for overtime conditions
+   * @returns true if overtime should start, false otherwise
+   */
+  private shouldTriggerOvertime(room: Room): boolean {
+    const availableLetters = LETTER_SETS[room.gameState.difficulty];
+    const allLettersUsed =
+      room.gameState.usedLetters.length >= availableLetters.length;
+    return allLettersUsed && room.gameState.activePlayers.length > 1;
+  }
+
   // Game state management
   startGame(roomCode: string, difficulty: Difficulty = 'easy'): Room | null {
     const room = this.rooms.get(roomCode);
@@ -222,11 +235,7 @@ export class GameStateManager {
     room.gameState.usedLetters.push(selectedLetter);
 
     // Check for overtime condition: all letters used and multiple players remaining
-    const availableLetters = LETTER_SETS[room.gameState.difficulty];
-    const allLettersUsed =
-      room.gameState.usedLetters.length >= availableLetters.length;
-
-    if (allLettersUsed && room.gameState.activePlayers.length > 1) {
+    if (this.shouldTriggerOvertime(room)) {
       return this.startOvertimeRound(roomCode);
     }
 
@@ -267,11 +276,7 @@ export class GameStateManager {
     }
 
     // Check for overtime condition: all letters used and multiple players remaining
-    const availableLetters = LETTER_SETS[room.gameState.difficulty];
-    const allLettersUsed =
-      room.gameState.usedLetters.length >= availableLetters.length;
-
-    if (allLettersUsed && room.gameState.activePlayers.length > 1) {
+    if (this.shouldTriggerOvertime(room)) {
       return this.startOvertimeRound(roomCode);
     }
 
@@ -336,6 +341,13 @@ export class GameStateManager {
     return { type: 'roundEnd', room };
   }
 
+  /**
+   * Starts an overtime round when all letters are used but multiple players remain.
+   * Increments overtime level, resets letters, assigns new category, and increases answer requirements.
+   *
+   * @param roomCode - The room code where overtime should start
+   * @returns EliminationResult with type 'overtimeStart' and updated room state, or null if room not found
+   */
   startOvertimeRound(roomCode: string): EliminationResult | null {
     const room = this.rooms.get(roomCode);
     if (!room) return null;

--- a/server/src/services/GameStateManager.ts
+++ b/server/src/services/GameStateManager.ts
@@ -4,7 +4,7 @@ import {
   EliminationResult,
   Difficulty,
 } from '../types';
-import { GAME_CONSTANTS } from '../constants';
+import { GAME_CONSTANTS, LETTER_SETS } from '../constants';
 import {
   generateRoomCode,
   createInitialGameState,
@@ -146,6 +146,17 @@ export class GameStateManager {
         this.startServerTimer(roomCode);
         break;
 
+      case 'overtimeStart':
+        // Broadcast overtime start with full game state
+        this.broadcastToRoom(roomCode, {
+          type: 'OVERTIME_START',
+          gameState: result.room.gameState,
+          overtimeLevel: result.room.gameState.overtimeLevel,
+          answersRequired: result.room.gameState.answersRequired,
+          newCategory: result.room.gameState.currentCategory,
+        });
+        break;
+
       case 'roundEnd':
         // Broadcast round end with full game state
         this.broadcastToRoom(roomCode, {
@@ -195,7 +206,7 @@ export class GameStateManager {
     return room;
   }
 
-  endTurn(roomCode: string, selectedLetter: string): Room | null {
+  endTurn(roomCode: string, selectedLetter: string): EliminationResult | null {
     const room = this.rooms.get(roomCode);
     if (!room) return null;
 
@@ -204,11 +215,20 @@ export class GameStateManager {
 
     // Only allow if timer is running
     if (!room.gameState.isTimerRunning) {
-      return room;
+      return { type: 'continue', room };
     }
 
     // Add letter to used letters
     room.gameState.usedLetters.push(selectedLetter);
+
+    // Check for overtime condition: all letters used and multiple players remaining
+    const availableLetters = LETTER_SETS[room.gameState.difficulty];
+    const allLettersUsed =
+      room.gameState.usedLetters.length >= availableLetters.length;
+
+    if (allLettersUsed && room.gameState.activePlayers.length > 1) {
+      return this.startOvertimeRound(roomCode);
+    }
 
     // Move to next player
     room.gameState.currentPlayerIndex =
@@ -221,7 +241,7 @@ export class GameStateManager {
     // Start timer for next player
     this.startServerTimer(roomCode);
 
-    return room;
+    return { type: 'continue', room };
   }
 
   eliminatePlayer(roomCode: string): EliminationResult | null {
@@ -246,6 +266,15 @@ export class GameStateManager {
       return this.endRound(roomCode);
     }
 
+    // Check for overtime condition: all letters used and multiple players remaining
+    const availableLetters = LETTER_SETS[room.gameState.difficulty];
+    const allLettersUsed =
+      room.gameState.usedLetters.length >= availableLetters.length;
+
+    if (allLettersUsed && room.gameState.activePlayers.length > 1) {
+      return this.startOvertimeRound(roomCode);
+    }
+
     // Adjust current player index
     if (
       room.gameState.currentPlayerIndex >= room.gameState.activePlayers.length
@@ -268,8 +297,15 @@ export class GameStateManager {
     this.clearTimer(roomCode);
 
     const winner = room.gameState.activePlayers[0];
+
+    // Calculate points based on round type
+    let pointsToAward = 1; // Default for normal rounds
+    if (room.gameState.isOvertimeRound) {
+      pointsToAward = room.gameState.answersRequired; // 2 for first overtime, 3 for second, etc.
+    }
+
     room.gameState.roundWins[winner] =
-      (room.gameState.roundWins[winner] || 0) + 1;
+      (room.gameState.roundWins[winner] || 0) + pointsToAward;
 
     // Check if game is over (first to 3 wins)
     if (room.gameState.roundWins[winner] >= GAME_CONSTANTS.WINS_TO_END_GAME) {
@@ -292,7 +328,38 @@ export class GameStateManager {
     room.gameState.roundActive = true; // Keep this TRUE for new round
     room.gameState.currentCategory = getRandomCategory();
 
+    // Reset overtime state for new round
+    room.gameState.isOvertimeRound = false;
+    room.gameState.overtimeLevel = 0;
+    room.gameState.answersRequired = 1;
+
     return { type: 'roundEnd', room };
+  }
+
+  startOvertimeRound(roomCode: string): EliminationResult | null {
+    const room = this.rooms.get(roomCode);
+    if (!room) return null;
+
+    // Clear any existing timer
+    this.clearTimer(roomCode);
+
+    // Increment overtime level and set answers required
+    room.gameState.overtimeLevel++;
+    room.gameState.answersRequired = room.gameState.overtimeLevel + 1; // 2 for first overtime, 3 for second, etc.
+    room.gameState.isOvertimeRound = true;
+
+    // Reset letters for overtime round
+    room.gameState.usedLetters = [];
+
+    // Get new category for overtime round
+    room.gameState.currentCategory = getRandomCategory();
+
+    // Reset timer and start with first player
+    room.gameState.currentPlayerIndex = 0;
+    room.gameState.timeLeft = GAME_CONSTANTS.TURN_TIME;
+    room.gameState.isTimerRunning = false; // Player needs to start turn
+
+    return { type: 'overtimeStart', room };
   }
 
   // Cleanup old rooms

--- a/server/src/services/__tests__/GameStateManager.test.ts
+++ b/server/src/services/__tests__/GameStateManager.test.ts
@@ -111,6 +111,158 @@ describe('GameStateManager', () => {
       });
     });
 
+    describe('Overtime Rounds', () => {
+      beforeEach(() => {
+        // Add a third player for more complex scenarios
+        gameManager.joinRoom(room.roomCode, 'player2');
+        gameManager.startGame(room.roomCode);
+      });
+
+      it('should trigger overtime when all letters are used with multiple players', () => {
+        const testRoom = gameManager.getRoom(room.roomCode)!;
+
+        // Start timer first
+        gameManager.startTurn(room.roomCode);
+
+        // Use all 18 letters (easy mode) - need to fill exactly 17 first
+        const easyLetters = [
+          'A',
+          'B',
+          'C',
+          'D',
+          'E',
+          'F',
+          'G',
+          'H',
+          'I',
+          'L',
+          'M',
+          'N',
+          'O',
+          'P',
+          'R',
+          'S',
+          'T',
+        ];
+        testRoom.gameState.usedLetters = [...easyLetters];
+
+        // End turn with the 18th letter - should trigger overtime
+        const result = gameManager.endTurn(room.roomCode, 'W');
+
+        expect(result?.type).toBe('overtimeStart');
+        expect(result?.room.gameState.isOvertimeRound).toBe(true);
+        expect(result?.room.gameState.overtimeLevel).toBe(1);
+        expect(result?.room.gameState.answersRequired).toBe(2);
+        expect(result?.room.gameState.usedLetters).toEqual([]); // Letters reset
+        expect(result?.room.gameState.currentCategory).toBeDefined(); // New category assigned
+      });
+
+      it('should not trigger overtime when all letters used but only one player remains', () => {
+        const testRoom = gameManager.getRoom(room.roomCode)!;
+
+        // Start timer first
+        gameManager.startTurn(room.roomCode);
+
+        // Eliminate players to leave only one
+        testRoom.gameState.activePlayers = ['host'];
+        testRoom.gameState.currentPlayerIndex = 0;
+
+        // Use all letters
+        const easyLetters = [
+          'A',
+          'B',
+          'C',
+          'D',
+          'E',
+          'F',
+          'G',
+          'H',
+          'I',
+          'L',
+          'M',
+          'N',
+          'O',
+          'P',
+          'R',
+          'S',
+          'T',
+        ];
+        testRoom.gameState.usedLetters = [...easyLetters];
+
+        // End turn with the last letter - should not trigger overtime (only one player)
+        const result = gameManager.endTurn(room.roomCode, 'W');
+
+        expect(result?.type).toBe('continue');
+        expect(result?.room.gameState.isOvertimeRound).toBe(false);
+      });
+
+      it('should escalate overtime levels correctly', () => {
+        const testRoom = gameManager.getRoom(room.roomCode)!;
+
+        // Start overtime round 1
+        const result1 = gameManager.startOvertimeRound(room.roomCode);
+        expect(result1?.room.gameState.overtimeLevel).toBe(1);
+        expect(result1?.room.gameState.answersRequired).toBe(2);
+
+        // Start overtime round 2
+        const result2 = gameManager.startOvertimeRound(room.roomCode);
+        expect(result2?.room.gameState.overtimeLevel).toBe(2);
+        expect(result2?.room.gameState.answersRequired).toBe(3);
+
+        // Start overtime round 3
+        const result3 = gameManager.startOvertimeRound(room.roomCode);
+        expect(result3?.room.gameState.overtimeLevel).toBe(3);
+        expect(result3?.room.gameState.answersRequired).toBe(4);
+      });
+
+      it('should award correct points for overtime rounds', () => {
+        const testRoom = gameManager.getRoom(room.roomCode)!;
+
+        // Set up overtime round 2 (3 answers required)
+        testRoom.gameState.isOvertimeRound = true;
+        testRoom.gameState.overtimeLevel = 2;
+        testRoom.gameState.answersRequired = 3;
+        testRoom.gameState.activePlayers = ['host']; // Only winner remains
+
+        const result = gameManager.endRound(room.roomCode);
+
+        expect(result?.room.gameState.roundWins['host']).toBe(3); // 3 points for 3-answer overtime
+      });
+
+      it('should reset overtime state for new rounds', () => {
+        const testRoom = gameManager.getRoom(room.roomCode)!;
+
+        // Set up overtime state
+        testRoom.gameState.isOvertimeRound = true;
+        testRoom.gameState.overtimeLevel = 2;
+        testRoom.gameState.answersRequired = 3;
+        testRoom.gameState.activePlayers = ['host']; // Only winner remains
+        testRoom.gameState.roundWins = { host: 0, player1: 0, player2: 0 }; // Initialize wins
+
+        const result = gameManager.endRound(room.roomCode);
+
+        // Only check for roundEnd type (not gameEnd) to verify overtime reset
+        if (result?.type === 'roundEnd') {
+          expect(result.room.gameState.isOvertimeRound).toBe(false);
+          expect(result.room.gameState.overtimeLevel).toBe(0);
+          expect(result.room.gameState.answersRequired).toBe(1);
+        } else {
+          // If game ends, just verify it doesn't continue overtime
+          expect(result?.type).toBe('gameEnd');
+        }
+      });
+
+      it('should assign new category for each overtime round', () => {
+        const testRoom = gameManager.getRoom(room.roomCode)!;
+        const originalCategory = testRoom.gameState.currentCategory;
+
+        const result = gameManager.startOvertimeRound(room.roomCode);
+
+        expect(result?.room.gameState.currentCategory).toBeDefined();
+        // Note: New category might be the same by chance, but the logic assigns a fresh one
+      });
+    });
+
     describe('Game End Conditions', () => {
       it('should end game when player wins required number of rounds', () => {
         // Simulate 3 wins for host

--- a/server/src/services/__tests__/GameStateManager.test.ts
+++ b/server/src/services/__tests__/GameStateManager.test.ts
@@ -73,8 +73,8 @@ describe('GameStateManager', () => {
 
       it('should not allow turn actions when timer is not running', () => {
         // End turn without starting it
-        const turnEnded = gameManager.endTurn(room.roomCode, 'A');
-        expect(turnEnded?.gameState.usedLetters).toHaveLength(0);
+        const turnResult = gameManager.endTurn(room.roomCode, 'A');
+        expect(turnResult?.room.gameState.usedLetters).toHaveLength(0);
       });
     });
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -24,6 +24,9 @@ export interface GameState {
   roundNumber: number;
   gameStarted: boolean;
   difficulty: 'easy' | 'hard';
+  isOvertimeRound: boolean;
+  overtimeLevel: number;
+  answersRequired: number;
 }
 
 export interface WebSocketMessage {
@@ -38,7 +41,7 @@ export interface ExtendedWebSocket extends WebSocket {
 }
 
 export type EliminationResult = {
-  type: 'continue' | 'roundEnd' | 'gameEnd';
+  type: 'continue' | 'roundEnd' | 'gameEnd' | 'overtimeStart';
   room: Room;
   winner?: string;
 };

--- a/server/src/utils/roomUtils.ts
+++ b/server/src/utils/roomUtils.ts
@@ -34,6 +34,9 @@ export function createInitialGameState(players: string[]): GameState {
     roundNumber: 1,
     gameStarted: false,
     difficulty: 'easy',
+    isOvertimeRound: false,
+    overtimeLevel: 0,
+    answersRequired: 1,
   };
 }
 


### PR DESCRIPTION
## Summary
- Implements progressive overtime rounds when all letters are used with multiple players remaining
- Overtime requirements escalate (2 answers → 3 answers → 4+ answers) with corresponding point rewards
- Fresh letter reset and new category selection for each overtime round
- Enhanced UI with amber styling and clear overtime indicators 
- Fixed network binding to enable cross-device multiplayer testing

## Test plan
- [x] Create multiplayer game on network devices
- [x] Play through all letters to trigger overtime
- [x] Verify overtime UI displays correctly
- [x] Test progressive requirements (2→3→4 answers)
- [x] Confirm point scaling works properly
- [x] Validate immediate overtime trigger (no stuck states)