### PR TITLE
fix: resolve e2e test failures with improved game state handling

### DIFF
--- a/client/src/components/KiaTereGame.tsx
+++ b/client/src/components/KiaTereGame.tsx
@@ -411,7 +411,7 @@ const KiaTereGame: React.FC = () => {
   // Lobby
   if (gameState === 'lobby') {
     return (
-      <div className="min-h-screen bg-slate-50 p-4">
+      <div className="min-h-screen bg-slate-50 p-4" data-testid="game-lobby">
         <div className="max-w-md mx-auto bg-white rounded-2xl shadow-lg border p-6">
           <div className="text-center mb-6">
             <h1 className="text-2xl font-bold text-slate-800 mb-2">
@@ -579,7 +579,10 @@ const KiaTereGame: React.FC = () => {
       ([_, wins]) => wins >= 3
     )?.[0];
     return (
-      <div className="min-h-screen bg-slate-50 p-4 flex items-center justify-center">
+      <div
+        className="min-h-screen bg-slate-50 p-4 flex items-center justify-center"
+        data-testid="game-over"
+      >
         <div className="bg-white rounded-2xl shadow-lg border p-8 text-center max-w-md">
           <Trophy className="w-16 h-16 text-amber-500 mx-auto mb-4" />
           <h1 className="text-3xl font-bold text-slate-800 mb-2">Game Over!</h1>
@@ -620,14 +623,17 @@ const KiaTereGame: React.FC = () => {
 
   // Playing Game
   return (
-    <div className="min-h-screen bg-slate-50 p-4">
+    <div className="min-h-screen bg-slate-50 p-4" data-testid="game-playing">
       <div className="max-w-4xl mx-auto">
         {/* Header */}
         <div className="bg-white rounded-2xl shadow-lg border p-6 mb-6">
           <div className="flex flex-wrap justify-between items-center gap-4">
             <div className="flex items-center gap-4">
               <h1 className="text-2xl font-bold text-slate-800">Kia Tere</h1>
-              <div className="flex items-center gap-2 text-sm text-slate-600">
+              <div
+                className="flex items-center gap-2 text-sm text-slate-600"
+                data-testid="round-indicator"
+              >
                 <Target className="w-4 h-4" />
                 Round {roundNumber}
               </div>

--- a/e2e/tests/complete-game-flow.spec.ts
+++ b/e2e/tests/complete-game-flow.spec.ts
@@ -41,16 +41,21 @@ test.describe("Complete Game Flow", () => {
       await startButton.click();
 
       // Step 4: Wait for game to start and verify game state
-      await expect(hostPage.locator("text=Game Lobby")).not.toBeVisible({ timeout: 10000 });
-      await expect(playerPage.locator("text=Game Lobby")).not.toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-lobby"]')).not.toBeVisible({ timeout: 10000 });
+      await expect(playerPage.locator('[data-testid="game-lobby"]')).not.toBeVisible({ timeout: 10000 });
 
-      // Verify game has started by checking for turn buttons or other game elements
-      const hostGameStarted = await hostPage.locator("button:has-text('Start Turn')").isVisible() ||
-                             await hostPage.locator("[data-testid='timer-container']").isVisible();
-      const playerGameStarted = await playerPage.locator("button:has-text('Start Turn')").isVisible() ||
-                               await playerPage.locator("[data-testid='timer-container']").isVisible();
+      // Wait for playing game UI to appear
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
+      await expect(playerPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
+
+      // Verify at least one player can start their turn
+      await hostPage.waitForTimeout(1000); // Give WebSocket time to sync
+      await playerPage.waitForTimeout(1000);
       
-      expect(hostGameStarted || playerGameStarted).toBe(true);
+      const hostCanStart = await hostPage.locator("button", { hasText: "Start Turn" }).isVisible();
+      const playerCanStart = await playerPage.locator("button", { hasText: "Start Turn" }).isVisible();
+      
+      expect(hostCanStart || playerCanStart).toBe(true);
 
       // Step 5: Identify whose turn it is and play through a few turns
       let currentPlayerPage = hostPage;

--- a/e2e/tests/concurrent-games.spec.ts
+++ b/e2e/tests/concurrent-games.spec.ts
@@ -113,10 +113,11 @@ test.describe("Concurrent Games", () => {
       console.log("Both concurrent games running independently");
 
     } finally {
-      await game1HostContext.close();
-      await game1PlayerContext.close();
-      await game2HostContext.close();
-      await game2PlayerContext.close();
+      // Close contexts with error handling
+      try { await game1HostContext.close(); } catch (e) { console.log('Error closing game1HostContext:', e); }
+      try { await game1PlayerContext.close(); } catch (e) { console.log('Error closing game1PlayerContext:', e); }
+      try { await game2HostContext.close(); } catch (e) { console.log('Error closing game2HostContext:', e); }
+      try { await game2PlayerContext.close(); } catch (e) { console.log('Error closing game2PlayerContext:', e); }
     }
   });
 
@@ -228,7 +229,7 @@ test.describe("Concurrent Games", () => {
       // Wait for all games to start
       for (let i = 0; i < 5; i++) {
         const hostPage = pages[i];
-        await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 15000 });
+        await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 15000 });
       }
 
       // Verify each game is in a valid state

--- a/e2e/tests/letter-selection.spec.ts
+++ b/e2e/tests/letter-selection.spec.ts
@@ -26,7 +26,7 @@ test.describe("Letter Selection Mechanics", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Find whose turn it is
       let currentPlayerPage = hostPage;
@@ -126,7 +126,7 @@ test.describe("Letter Selection Mechanics", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Find whose turn it is and who is waiting
       let currentPlayerPage = hostPage;
@@ -203,7 +203,7 @@ test.describe("Letter Selection Mechanics", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Play a turn and complete it to mark a letter as used
       let currentPlayerPage = hostPage;
@@ -300,7 +300,7 @@ test.describe("Letter Selection Mechanics", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Find whose turn it is
       let currentPlayerPage = hostPage;

--- a/e2e/tests/overtime-modes.spec.ts
+++ b/e2e/tests/overtime-modes.spec.ts
@@ -232,8 +232,8 @@ test.describe("Overtime and Special Game Modes", () => {
       while (rounds < maxRounds) {
         // Check for end game conditions
         const endGameIndicators = [
-          hostPage.locator("text=/game.*end|final.*round|winner|congratulations/i"),
-          playerPage.locator("text=/game.*end|final.*round|winner|congratulations/i"),
+          hostPage.locator('[data-testid="game-over"]'),
+          playerPage.locator('[data-testid="game-over"]'),
           hostPage.locator("button", { hasText: /new.*game|play.*again|return.*menu/i }),
           playerPage.locator("button", { hasText: /new.*game|play.*again|return.*menu/i }),
         ];
@@ -380,8 +380,8 @@ test.describe("Overtime and Special Game Modes", () => {
       // Even if no tie-breaking is detected, game should be in valid state
       const gameValid = await hostPage.locator("button:has-text('Start Turn')").isVisible() ||
                        await playerPage.locator("button:has-text('Start Turn')").isVisible() ||
-                       await hostPage.locator("text=/winner|end/i").isVisible() ||
-                       await playerPage.locator("text=/winner|end/i").isVisible();
+                       await hostPage.locator('[data-testid="game-over"]').isVisible() ||
+                       await playerPage.locator('[data-testid="game-over"]').isVisible();
       
       expect(gameValid).toBe(true);
       

--- a/e2e/tests/round-progression.spec.ts
+++ b/e2e/tests/round-progression.spec.ts
@@ -26,7 +26,7 @@ test.describe("Round Progression and Scoring", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Verify we start at Round 1
       await expect(hostPage.locator("text=/Round 1/")).toBeVisible();
@@ -109,7 +109,7 @@ test.describe("Round Progression and Scoring", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Verify initial scores are 0
       const scoreIndicators = [
@@ -177,7 +177,7 @@ test.describe("Round Progression and Scoring", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Play one turn to use a letter
       let currentPlayerPage = hostPage;
@@ -273,7 +273,7 @@ test.describe("Round Progression and Scoring", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Look for game end conditions (usually first to 3 wins)
       const gameEndIndicators = [

--- a/e2e/tests/timer-elimination.spec.ts
+++ b/e2e/tests/timer-elimination.spec.ts
@@ -26,7 +26,7 @@ test.describe("Timer and Elimination", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Find whose turn it is
       let currentPlayerPage = hostPage;
@@ -91,7 +91,7 @@ test.describe("Timer and Elimination", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Find whose turn it is
       let currentPlayerPage = hostPage;
@@ -164,7 +164,7 @@ test.describe("Timer and Elimination", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Find whose turn it is
       let currentPlayerPage = hostPage;

--- a/e2e/tests/turn-mechanics.spec.ts
+++ b/e2e/tests/turn-mechanics.spec.ts
@@ -26,7 +26,7 @@ test.describe("Turn Mechanics", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Track turn order for multiple turns
       const turnOrder = [];
@@ -126,7 +126,7 @@ test.describe("Turn Mechanics", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Check visual indicators for whose turn it is
       const hostCanStart = await hostPage.locator("button", { hasText: "Start Turn" }).isVisible();
@@ -205,7 +205,7 @@ test.describe("Turn Mechanics", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Execute one complete turn and verify smooth transition
       let currentPlayerPage = hostPage;
@@ -280,7 +280,7 @@ test.describe("Turn Mechanics", () => {
       
       // Start game
       await hostPage.locator("button", { hasText: "Start Game" }).click();
-      await expect(hostPage.locator("text=/Round|Turn|Game/")).toBeVisible({ timeout: 10000 });
+      await expect(hostPage.locator('[data-testid="game-playing"]')).toBeVisible({ timeout: 10000 });
 
       // Verify only one player can start a turn at any time
       const hostCanStart = await hostPage.locator("button", { hasText: "Start Turn" }).isVisible();

--- a/server/src/services/WebSocketServer.ts
+++ b/server/src/services/WebSocketServer.ts
@@ -206,11 +206,16 @@ export class WebSocketServer {
     }
 
     const difficulty = message.difficulty || 'easy';
-    this.gameManager.startGame(ws.roomCode!, difficulty);
+    const updatedRoom = this.gameManager.startGame(ws.roomCode!, difficulty);
+
+    if (!updatedRoom) {
+      this.sendError(ws, 'Failed to start game');
+      return;
+    }
 
     this.broadcastToRoom(ws.roomCode!, {
       type: 'GAME_STARTED',
-      gameState: room.gameState,
+      gameState: updatedRoom.gameState,
     });
 
     console.log(


### PR DESCRIPTION
## Summary
- Fix critical WebSocket server bug where stale room state was used after game start
- Add reliable data-testid selectors to replace ambiguous text-based selectors
- Improve test reliability with better state transition handling and defensive context cleanup

## Technical Changes
- **WebSocket Server**: Fixed `handleStartGame` to use updated room state from `gameManager.startGame()`
- **Client Components**: Added `data-testid` attributes for game states (lobby, playing, game-over)
- **E2E Tests**: Replaced problematic `text=/Round|Turn|Game/` selectors that caused strict mode violations
- **Test Reliability**: Added proper waits for state transitions and defensive context cleanup

## Test Impact
This should resolve the 26 failing e2e tests that were experiencing:
- Games not transitioning from lobby to playing state properly
- Strict mode violations from ambiguous selectors
- Timeout issues from improper context cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)